### PR TITLE
Config files to deploy to OpenShift

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,2 @@
+FROM base-shiny:latest
+ADD . /code

--- a/Shiny_Startup_v1.R
+++ b/Shiny_Startup_v1.R
@@ -73,7 +73,7 @@ source("Shiny_MailMerge_v1.R")
 source("Shiny_TMTSPQC_v1.R")
 source("Shiny_Interactive_v1.R")
 source("Shiny_MVA_v1.R")
-source("Shiny_Tables_v1.R")
+#source("Shiny_Tables_v1.R")
 
 
 

--- a/Shiny_Startup_v1.R
+++ b/Shiny_Startup_v1.R
@@ -73,7 +73,7 @@ source("Shiny_MailMerge_v1.R")
 source("Shiny_TMTSPQC_v1.R")
 source("Shiny_Interactive_v1.R")
 source("Shiny_MVA_v1.R")
-#source("Shiny_Tables_v1.R")
+source("Shiny_Tables_v1.R")
 
 
 

--- a/base-shiny/Dockerfile
+++ b/base-shiny/Dockerfile
@@ -1,7 +1,7 @@
 FROM rocker/shiny-verse:4.0.2
 
 RUN apt-get update
-RUN apt-get install build-essential libgl1-mesa-dev libglu1-mesa-dev libv8-dev libglpk-dev -y
+RUN apt-get install build-essential libgl1-mesa-dev libglu1-mesa-dev libv8-dev libglpk-dev libbz2-dev liblzma-dev -y
 
 ADD ./Shiny_install.R /code/Shiny_install.R
 RUN Rscript /code/Shiny_install.R

--- a/base-shiny/Dockerfile
+++ b/base-shiny/Dockerfile
@@ -6,7 +6,6 @@ RUN apt-get install build-essential libgl1-mesa-dev libglu1-mesa-dev libv8-dev l
 ADD ./Shiny_install.R /code/Shiny_install.R
 RUN Rscript /code/Shiny_install.R
 
-ADD . /code
 COPY base-shiny/shiny-server.conf /etc/shiny-server/shiny-server.conf
 RUN chown -R shiny /var/lib/shiny-server/
 

--- a/base-shiny/Dockerfile
+++ b/base-shiny/Dockerfile
@@ -1,0 +1,24 @@
+FROM rocker/shiny-verse:4.0.2
+
+RUN apt-get update
+RUN apt-get install build-essential libgl1-mesa-dev libglu1-mesa-dev libv8-dev libglpk-dev -y
+
+ADD ./Shiny_install.R /code/Shiny_install.R
+RUN Rscript /code/Shiny_install.R
+
+ADD . /code
+COPY base-shiny/shiny-server.conf /etc/shiny-server/shiny-server.conf
+RUN chown -R shiny /var/lib/shiny-server/
+
+# OpenShift gives a random uid for the user and some programs try to find a username from the /etc/passwd.
+# Let user to fix it, but obviously this shouldn't be run outside OpenShift
+RUN chmod ug+rw /etc/passwd
+COPY base-shiny/fix-username.sh /fix-username.sh
+COPY base-shiny/shiny-server.sh /usr/bin/shiny-server.sh
+RUN chmod a+rx /usr/bin/shiny-server.sh
+
+# Make sure the directory for individual app logs exists and is usable
+RUN chmod -R a+rwX /var/log/shiny-server
+RUN chmod -R a+rwX /var/lib/shiny-server
+
+CMD /usr/bin/shiny-server.sh

--- a/base-shiny/fix-username.sh
+++ b/base-shiny/fix-username.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+tempfile=$(mktemp)
+sed -e "s/^shiny.*//g" /etc/passwd > $tempfile
+cp $tempfile /etc/passwd
+echo "shiny:x:$(id -u):$(id -g)::/tmp:/bin/bash" >> /etc/passwd
+rm -f $tempfile

--- a/base-shiny/shiny-server.conf
+++ b/base-shiny/shiny-server.conf
@@ -1,0 +1,23 @@
+# Instruct Shiny Server to run applications as the user "shiny"
+run_as shiny;
+
+app_init_timeout 180;
+
+# Define a server that listens on port 3838
+server {
+  listen 3838;
+
+  # Define a location at the base URL
+  location / {
+
+    # Host the directory of Shiny Apps stored in this directory
+    site_dir /code;
+
+    # Log all Shiny output to files in this directory
+    log_dir /var/log/shiny-server;
+
+    # When a user visits the base URL rather than a particular application,
+    # an index of the applications available in this directory will be shown.
+    directory_index on;
+  }
+}

--- a/base-shiny/shiny-server.sh
+++ b/base-shiny/shiny-server.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+sh /fix-username.sh
+
+# Make sure the directory for individual app logs exists
+#mkdir -p /var/log/shiny-server
+#chown shiny.shiny /var/log/shiny-server
+
+if [ "$APPLICATION_LOGS_TO_STDOUT" = "false" ];
+then
+    exec shiny-server 2>&1
+else
+    # start shiny server in detached mode
+    exec shiny-server 2>&1 &
+
+    # push the "real" application logs to stdout with xtail
+    exec xtail /var/log/shiny-server/
+
+fi

--- a/openshift/Build.yaml
+++ b/openshift/Build.yaml
@@ -15,7 +15,7 @@ items:
       description: Keeps track of changes in the app
     labels:
       app: spd
-    name: ddh-shiny-app
+    name: spd-shiny-app
 - apiVersion: build.openshift.io/v1
   kind: BuildConfig
   metadata:
@@ -31,14 +31,13 @@ items:
         kind: ImageStreamTag
         name: base-shiny:latest
     source:
-      contextDir: "base-shiny"
       git:
         ref: master
         uri: https://github.com/gmw12/shiny_PD.git
       type: Git
     strategy:
       dockerStrategy:
-        dockerfilePath: Dockerfile
+        dockerfilePath: base-shiny/Dockerfile
     triggers:
     - type: ImageChange
     - type: ConfigChange

--- a/openshift/Build.yaml
+++ b/openshift/Build.yaml
@@ -1,0 +1,74 @@
+apiVersion: v1
+items:
+- apiVersion: image.openshift.io/v1
+  kind: ImageStream
+  metadata:
+    annotations:
+      description: Keeps track of changes in the base shiny image
+    labels:
+      app: spd
+    name: base-shiny
+- apiVersion: image.openshift.io/v1
+  kind: ImageStream
+  metadata:
+    annotations:
+      description: Keeps track of changes in the app
+    labels:
+      app: spd
+    name: ddh-shiny-app
+- apiVersion: build.openshift.io/v1
+  kind: BuildConfig
+  metadata:
+    annotations:
+      description: Build config for base shiny application
+      template.alpha.openshift.io/wait-for-ready: "true"
+    labels:
+      app: spd
+    name: base-shiny
+  spec:
+    output:
+      to:
+        kind: ImageStreamTag
+        name: base-shiny:latest
+    source:
+      contextDir: "base-shiny"
+      git:
+        ref: master
+        uri: https://github.com/gmw12/shiny_PD.git
+      type: Git
+    strategy:
+      dockerStrategy:
+        dockerfilePath: Dockerfile
+    triggers:
+    - type: ImageChange
+    - type: ConfigChange
+- apiVersion: build.openshift.io/v1
+  kind: BuildConfig
+  metadata:
+    annotations:
+      description: Build config for spd shiny application
+      template.alpha.openshift.io/wait-for-ready: "true"
+    labels:
+      app: spd
+    name: spd-shiny-app
+  spec:
+    output:
+      to:
+        kind: ImageStreamTag
+        name: spd-shiny-app:latest
+    source:
+      git:
+        ref: master
+        uri: https://github.com/gmw12/shiny_PD.git
+      type: Git
+    strategy:
+      dockerStrategy:
+        from:
+          kind: ImageStreamTag
+          name: base-shiny:latest
+        dockerfilePath: Dockerfile
+    triggers:
+    - type: ImageChange
+    - type: ConfigChange
+kind: List
+metadata: {}

--- a/openshift/Deployment.yaml
+++ b/openshift/Deployment.yaml
@@ -1,0 +1,85 @@
+apiVersion: v1
+items:
+- apiVersion: apps.openshift.io/v1
+  kind: DeploymentConfig
+  metadata:
+    annotations:
+      description: SPD Shiny Server deployment
+      template.alpha.openshift.io/wait-for-ready: "true"
+    labels:
+      app: spd
+    name: spd-shiny-app
+  spec:
+    replicas: 1
+    strategy:
+      type: Rolling
+    template:
+      metadata:
+        labels:
+          app: spd
+        name: spd-shiny-app
+      spec:
+        containers:
+        - image: spd-shiny-app:latest
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 3838
+            initialDelaySeconds: 30
+            timeoutSeconds: 30
+          name: spd-shiny-app
+          ports:
+          - containerPort: 3838
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 3838
+            initialDelaySeconds: 30
+            timeoutSeconds: 30
+          resources:
+            requests:
+              memory: 1G
+          volumeMounts:
+          - mountPath: /data
+            name: spd-data
+        volumes:
+        - name: spd-data
+          persistentVolumeClaim:
+            claimName: spd-data-pvc
+    triggers:
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - spd-shiny-app
+        from:
+          kind: ImageStreamTag
+          name: spd-shiny-app:latest
+      type: ImageChange
+    - type: ConfigChange
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      app: spd
+    name: spd-shiny-app
+  spec:
+    ports:
+    - name: spd-shiny-service
+      port: 80
+      protocol: TCP
+      targetPort: 3838
+    selector:
+      app: spd
+- apiVersion: v1
+  kind: Route
+  metadata:
+    labels:
+      app: spd
+    name: spd-shiny-route
+  spec:
+    path: /
+    to:
+      kind: Service
+      name: spd-shiny-app
+kind: List
+metadata: {}

--- a/openshift/README.md
+++ b/openshift/README.md
@@ -1,0 +1,19 @@
+ddh-app
+=======
+
+OpenShift deployment of spd application using shiny server
+## Contents
+
+- Storage.yaml: Configuration for requesting persistent storage to house data
+- Build.yaml: Build configurations and image streams for base image and application image
+- Deployment.yaml: Deployment configuration to run application pods
+
+We have a two step build process(base image and application image) so code changes can be deployed quickly.
+Otherwise code changes would require waiting for all requirements to be installed.
+
+## Deployment
+
+1. Create shared storage `oc create -f Storage.yaml`
+3. Create Build and image configurations `oc create -f Build.yaml`
+4. Deploy application: `oc create -f Deployment.yaml`
+5. Ask openshift for the application route: `oc get route spd-shiny-route`

--- a/openshift/README.md
+++ b/openshift/README.md
@@ -1,4 +1,4 @@
-ddh-app
+spd-app
 =======
 
 OpenShift deployment of spd application using shiny server

--- a/openshift/Storage.yaml
+++ b/openshift/Storage.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+items:
+- apiVersion: v1
+  kind: PersistentVolumeClaim
+  metadata:
+    labels:
+      app: spd
+    name: spd-data-pvc
+  spec:
+    accessModes:
+    - ReadWriteMany
+    resources:
+      requests:
+        storage: 5Gi
+kind: List


### PR DESCRIPTION
Adds files to deploy this shiny app on an OpenShift cluster consisting of
- Files describing OpenShift compatible R Docker images 
- OpenShift templates to build and deploy the docker images

## Docker files
Files in the `base-shiny` directory are configuration to create a base Docker image containing all the requirements for running this application. This uses R version 4.0.2 from the [rocker/shiny-verse:4.0.2](https://github.com/rocker-org/rocker-versioned2) repo.
A top level `Dockerfile` adds the current R code to the `base-shiny` image to create our application image.

## OpenShift files
Files in the `openshift` directory create the following items
- 5 GB storage volume to hold user data
- Build to create an image named `base-shiny` to install requirements including [Shiny_install.R](https://github.com/Duke-GCB/shiny_PD/blob/master/Shiny_install.R)
- Build to create an image named `spd-shiny-app` to run the application based on `base-shiny`
- Deployment that will run pods to run the application using the `spd-shiny-app` image

## Remaining Issues
- I used the name `spd` just based on the initials of this project. If there is a better name for it I would like to update the config files to more accurately represent this project.
- The `Shiny_Startup_v1.R` files references `Shiny_Tables_v1.R` which does not currently exist in this repo.
https://github.com/gmw12/shiny_PD/blob/5c974bc537229992436c8a0caeea45eb2eb10aff/Shiny_Startup_v1.R#L76

I created a test deployment in our OpenShift cluster after removing the line which sources `Shiny_Tables_v1.R`.
The app runs and displays options to select data but the app may break due to not sourcing Shiny_Tables_v1.R.
Another issue is the app also only lets you select from data stored within the pods instead of uploading.
If you would like I can email you the URL to the test deployment.

Any feedback is welcomed.

Thanks.